### PR TITLE
Added missing dependency

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -90,6 +90,7 @@ grails.project.dependency.resolution = {
         runtime("com.lowagie:itext:2.1.7") { excludes "bouncycastle:bcprov-jdk14:138", "org.bouncycastle:bcprov-jdk14:1.38" } //not needed by icescrum
         compile("com.lowagie:itext:2.1.7") { excludes "bouncycastle:bcprov-jdk14:138", "org.bouncycastle:bcprov-jdk14:1.38" } //not needed by icescrum
         runtime 'mysql:mysql-connector-java:5.1.40'
+        runtime 'org.apache.httpcomponents:httpclient:4.5'
         compile 'commons-fileupload:commons-fileupload:1.3.3' //fix CVE-2016-1000031
     }
     plugins {


### PR DESCRIPTION
I was unable to compile to a war file without this runtime dependency: `org.apache.httpcomponents:httpclient`.